### PR TITLE
- fix nfo parsing with mixed lineendings

### DIFF
--- a/sickchill/providers/metadata/generic.py
+++ b/sickchill/providers/metadata/generic.py
@@ -292,11 +292,17 @@ class GenericMetadata(object):
                     try:
                         if not hasattr(ep_obj, attribute_map[attribute]):
                             continue
-
                         node = episodeXML.find(attribute)
-                        if node is None or node.text == str(getattr(ep_obj, attribute_map[attribute])):
+                        if node is None:
                             continue
 
+                        # line endings read from xml file with ElementTree and access with node.text changes the lineendings to \r\n (also from \n) 
+                        # also the xml can contain mixed line endings and this seems to be a problem with python (https://stackoverflow.com/questions/1749466/whats-the-most-pythonic-way-of-normalizing-lineends-in-a-string),
+                        # so remove all lineendings before compairing for now
+                        text1 = ''.join(node.text.splitlines())
+                        text2 = ''.join(str(getattr(ep_obj, attribute_map[attribute])).splitlines())
+                        if text1 == text2:
+                            continue
                         node.text = str(getattr(ep_obj, attribute_map[attribute]))
                         changed = True
                     except AttributeError:


### PR DESCRIPTION
	line endings read from xml file with ElementTree and access
	with node.text changes the lineendings to \r\n (also from \n) also
   	the xml can contain mixed line endings and this seems to be a
        problem with python
	(https://stackoverflow.com/questions/1749466/whats-the-most-pythonic-way-of-normalizing-lineends-in-a-string),
	so remove all lineendings before compairing for now

Fixes #

Proposed changes in this pull request:
-
-
-

- [ ] PR is based on the DEVELOP branch
- [ ] Don't send big changes all at once. Split up big PRs into multiple smaller PRs that are easier to manage and review
- [ ] Read [contribution guide](https://github.com/SickChill/SickChill/blob/master/.github/CONTRIBUTING.md)
